### PR TITLE
Updated to new dependency location

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ repositories {
 }
 
 dependencies {
-    compile group: 'com.yammer.dropwizard', name: 'dropwizard-core', version: '0.5.1'
+    compile group: 'io.dropwizard', name: 'dropwizard-core', version: '0.9.0'
 }
 
 apply plugin: 'application'


### PR DESCRIPTION
Version 0.7.0 has been moved to io.dropwizard, so somebody seeing your build.gradle example might want to update accordingly.
